### PR TITLE
add pre-commit hooks isort and black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+      - id: black
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.7.0
+    hooks:
+      - id: isort


### PR DESCRIPTION
Hi,
This fixes issue #48 
I used the following resource : [https://towardsdatascience.com/4-pre-commit-plugins-to-automate-code-reviewing-and-formatting-in-python-c80c6d2e9f5](https://towardsdatascience.com/4-pre-commit-plugins-to-automate-code-reviewing-and-formatting-in-python-c80c6d2e9f5)

Below are resource for further reading :
1. [pre-commit](https://pypi.org/project/pre-commit/) python package
2. it is also interesting to have a look at how [git hooks](https://www.git-scm.com/docs/githooks#pre-receive) works :
- https://www.git-scm.com/docs/githooks#pre-receive
- https://githooks.com/


Basically, whenever you make a commit to a file, it will automatically run isort and black against staged file (i.e ready to be commit). The commit won't succeed and you'll receive a notification to update staged files to include autoformatting modifications.

In order to test :
- pull modification locally
- update a file (add some space or line return inside the file)
- commit the file and see how git behave by automatically formatting the file before commit