### PR TITLE
Correct "'" as a valid operator

### DIFF
--- a/borb/io/read/types.py
+++ b/borb/io/read/types.py
@@ -264,7 +264,7 @@ class CanvasOperatorName:
         "v",
         "w", "W", "W*",
         "y",
-        "''",
+        "'",
         '"',
     ]
     # fmt: on


### PR DESCRIPTION
There was a typo in the entry for ' as a valid operator (MoveToNextLineShowText), this was causing it to get ignored in processing.  I had a PDF file that was not extracting text correctly and this was the culprit.