### PR TITLE
Fix compressed_jpeg_image_transformer.py to use decoded bytes instead of original

### DIFF
--- a/borb/io/read/image/compressed_jpeg_image_transformer.py
+++ b/borb/io/read/image/compressed_jpeg_image_transformer.py
@@ -69,8 +69,8 @@ class CompressedJPEGImageTransformer(Transformer):
         # re-apply filter
         filters.append(Name("DCTDecode"))
 
-        # use PIL to read image bytes
-        raw_byte_array = object_to_transform["Bytes"]
+        # use PIL to read decoded image bytes
+        raw_byte_array = object_to_transform["DecodedBytes"]
 
         try:
             tmp = Image.open(io.BytesIO(raw_byte_array))


### PR DESCRIPTION
After calling decode_stream() to deflate the image stream  before handing it off to PIL, reference "DecodedBytes" instead of "Bytes" as "Bytes" is the original stream data instead of the decoded data.