### PR TITLE
Update low_level_tokenizer.py

### DIFF
--- a/borb/io/read/tokenize/low_level_tokenizer.py
+++ b/borb/io/read/tokenize/low_level_tokenizer.py
@@ -236,7 +236,7 @@ class LowLevelTokenizer:
             while True:
                 ch = self._next_byte()
                 if len(ch) == 0:
-                    break
+                    return None
                 # escape char
                 if ch == b"\\":
                     ch = self._next_byte()


### PR DESCRIPTION
avoid an assert error when pdf stream '(' doesn't match its ')'